### PR TITLE
fix release workflow, no inspector on wasm release

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build
         run: |
-          cargo build --release --target x86_64-unknown-linux-gnu
+          cargo build --release --target x86_64-unknown-linux-gnu --no-default-features
 
       - name: Set file name
         id: set_file_name

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ env:
   # - Write "intel" and "apple" to abbreviate "macos_intel" and "macos_apple_silicon," respectively.
   # - Write "macos" to build for both "intel" and "apple"
   # - Write "web" or "wasm" to build for the web
-  build_for: "web, linux"
+  build_for: "web"
 
   # Releases
 

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build
         run: |
-          cargo build --release --target wasm32-unknown-unknown
+          cargo build --release --target wasm32-unknown-unknown --no-default-features
 
       - name: Set file name
         id: set_file_name

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "KrillingWithChtulhu"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "bevy-inspector-egui",
+ "bevy_asset_loader",
+ "bevy_rapier2d",
+]
+
+[[package]]
 name = "ab_glyph"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2381,16 +2391,6 @@ dependencies = [
  "libc",
  "libloading 0.7.4",
  "pkg-config",
-]
-
-[[package]]
-name = "krilling-with-cthulhu"
-version = "0.1.0"
-dependencies = [
- "bevy",
- "bevy-inspector-egui",
- "bevy_asset_loader",
- "bevy_rapier2d",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "krilling-with-cthulhu"
+name = "KrillingWithChtulhu"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0 OR CC0-1.0"
@@ -17,6 +17,10 @@ opt-level = 3
 
 [dependencies]
 bevy = "0.12"
-bevy-inspector-egui = "0.21.0"
+bevy-inspector-egui = {version = "0.21.0", optional = true }
 bevy_asset_loader = { version = "0.18.0", features = ["2d"] }
 bevy_rapier2d = "0.23.0"
+
+[features]
+default = ["debug"]
+debug = ["dep:bevy-inspector-egui"]


### PR DESCRIPTION
These changes allow us to still use the inspector during development, but the wasm build will use `cargo build --release --no-default-features`, allowing us to fix the inspector compile error